### PR TITLE
Add dark mode and filtering controls

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1,0 +1,20 @@
+/* Component styles */
+:root {
+  --background-color: #ffffff;
+  --text-color: #000000;
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.dark {
+  --background-color: #222222;
+  --text-color: #eeeeee;
+}
+
+.controls button {
+  margin-right: 0.5rem;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,26 @@
+// Main theme JavaScript
+
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('dark-mode-toggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+    });
+  }
+
+  const filters = document.querySelectorAll('[data-filter]');
+  const items = document.querySelectorAll('[data-category]');
+
+  filters.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const category = btn.getAttribute('data-filter');
+      items.forEach(item => {
+        if (!category || item.getAttribute('data-category') === category) {
+          item.style.display = '';
+        } else {
+          item.style.display = 'none';
+        }
+      });
+    });
+  });
+});

--- a/template-parts/labs/ui-components.php
+++ b/template-parts/labs/ui-components.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * UI Components listing with dark mode and category filtering.
+ */
+
+$components = [
+    ['title' => 'Primary Button', 'category' => 'buttons'],
+    ['title' => 'Card Layout', 'category' => 'cards'],
+    ['title' => 'Input Field', 'category' => 'forms'],
+];
+?>
+<div class="controls">
+    <button id="dark-mode-toggle">Toggle Dark Mode</button>
+    <button data-filter="">All</button>
+    <button data-filter="buttons">Buttons</button>
+    <button data-filter="cards">Cards</button>
+    <button data-filter="forms">Forms</button>
+</div>
+<div class="components">
+<?php foreach ($components as $component) : ?>
+    <div class="ui-component" data-category="<?php echo esc_attr($component['category']); ?>">
+        <?php echo esc_html($component['title']); ?>
+    </div>
+<?php endforeach; ?>
+</div>


### PR DESCRIPTION
## Summary
- add JS to toggle dark mode and filter UI components
- define dark/light styles in component CSS
- output category attributes and filter controls in the components template

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860da9656a8832bbd7fc90c8a019f65